### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,9 +19,9 @@ PynamoDB presents you with a simple, elegant API.
 
 Useful links:
 
-* See the full documentation at http://pynamodb.readthedocs.org/
+* See the full documentation at https://pynamodb.readthedocs.io/
 * Ask questions at `Google group <https://groups.google.com/forum/#!forum/pynamodb>`_
-* See release notes at http://pynamodb.readthedocs.org/en/latest/release_notes.html
+* See release notes at https://pynamodb.readthedocs.io/en/latest/release_notes.html
 
 Installation
 ============

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -17,7 +17,7 @@ Why PynamoDB?
 ^^^^^^^^^^^^^
 
 It all started when I needed to use Global Secondary Indexes, a new and powerful feature of
-DynamoDB. I quickly realized that my go to library, `dynamodb-mapper <http://dynamodb-mapper.readthedocs.org/en/latest/>`__, didn't support them.
+DynamoDB. I quickly realized that my go to library, `dynamodb-mapper <https://dynamodb-mapper.readthedocs.io/en/latest/>`__, didn't support them.
 In fact, it won't be supporting them anytime soon because dynamodb-mapper relies on another
 library, `boto.dynamodb <http://docs.pythonboto.org/en/latest/migrations/dynamodb_v1_to_v2.html>`__,
 which itself won't support them. In fact, boto doesn't support
@@ -31,7 +31,7 @@ Installation
     $ pip install pynamodb
 
 
-Don't have pip? `Here are instructions for installing pip. <http://pip.readthedocs.org/en/latest/installing.html>`_.
+Don't have pip? `Here are instructions for installing pip. <https://pip.readthedocs.io/en/latest/installing.html>`_.
 
 Getting Started
 ^^^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ PynamoDB provides three API levels, a ``Connection``, a ``TableConnection``, and
 Each API is built on top of the previous, and adds higher level features. Each API level is
 fully featured, and can be used directly. Before you begin, you should already have an
 `Amazon Web Services account <http://aws.amazon.com/>`__, and have your
-`AWS credentials configured your boto <http://boto.readthedocs.org/en/latest/boto_config_tut.html>`__.
+`AWS credentials configured your boto <https://boto.readthedocs.io/en/latest/boto_config_tut.html>`__.
 
 Defining a Model
 ----------------

--- a/examples/url_shortener/README.rst
+++ b/examples/url_shortener/README.rst
@@ -5,7 +5,7 @@ A very short URL shortener
 This is a very small implementation of a `URL shortener <http://en.wikipedia.org/wiki/URL_shortening>`_ powered by Flask and PynamoDB.
 This example works with both Python 2 and Python 3.
 
-Try it for yourself in three easy steps, assuming you have `access to AWS <http://pynamodb.readthedocs.org/en/latest/awsaccess.html>`_.
+Try it for yourself in three easy steps, assuming you have `access to AWS <https://pynamodb.readthedocs.io/en/latest/awsaccess.html>`_.
 
 Install Requirements
 ====================

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -1160,7 +1160,7 @@ class Model(with_metaclass(MetaModel)):
         if not hasattr(cls, "Meta") or cls.Meta.table_name is None:
             raise AttributeError(
                 """As of v1.0 PynamoDB Models require a `Meta` class.
-                See http://pynamodb.readthedocs.org/en/latest/release_notes.html"""
+                See https://pynamodb.readthedocs.io/en/latest/release_notes.html"""
             )
         if cls._connection is None:
             cls._connection = TableConnection(cls.Meta.table_name, region=cls.Meta.region, host=cls.Meta.host,


### PR DESCRIPTION
…projects

As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.